### PR TITLE
Update kernel and initrd paths for Gentoo

### DIFF
--- a/grub2/inc-gentoo.cfg
+++ b/grub2/inc-gentoo.cfg
@@ -12,7 +12,7 @@ for isofile in $isopath/gentoo/install-*-minimal-*.iso; do
     set isoname=$3
     echo "Using ${isoname}..."
     loopback loop $isofile
-    linux (loop)/isolinux/gentoo isoboot=${isofile} root=/dev/ram0 init=/linuxrc  dokeymap looptype=squashfs loop=/image.squashfs  cdroot docache
-    initrd (loop)/isolinux/gentoo.igz
+    linux (loop)/boot/gentoo isoboot=${isofile} root=/dev/ram0 init=/linuxrc  dokeymap looptype=squashfs loop=/image.squashfs  cdroot docache
+    initrd (loop)/boot/gentoo.igz
   }
 done


### PR DESCRIPTION
As discussed [here](https://github.com/thias/glim/pull/50), this fixes the Gentoo config. Ideally, the config for Calculate should be checked as well.